### PR TITLE
Run swabber as a forking systemd service

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,22 @@ NB: On Debian 9, you may need to create the <code>/usr/local/lib/python2.7/dist-
 
 The <code>swabberd</code> file can be used as an init script if you're installing the package by hand.
 
+
+The SystemD service file can be used to manage the swabber daemon. It can be installed as follows:
+
+
+    cp ../initscript/swabberd.service /lib/systemd/system/swabber.service
+
+    systemctl enable swabber
+    systemctl start swabber
+    systemctl status swabber
+
+
+
 The <code>banpub-faker.py</code> example publisher also requires the Tornado Python library which can be installed with:
 
     apt-get install python-tornado
-   
+
 
 iptables interface
 -------------

--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ The <code>swabberd</code> file can be used as an init script if you're installin
 
 The SystemD service file can be used to manage the swabber daemon. It can be installed as follows:
 
+    Note: If you already had /etc/init.d/swabberd installed, it is recommended to remove this from
+    all runlevels first.
+
+    update-rc.d -f swabberd remove
+    rm /etc/init.d/swabberd
+
+    Install systemD swabber service:
 
     cp ../initscript/swabberd.service /lib/systemd/system/swabber.service
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ interface: <iptables match>
 -------------
 *iptables and iptables_cmd interfaces only*
 
-This is the interface to issue ban rules for. Can be of the iptables match format- it already defaults to eth+, for example.
+This is the interface to issue ban rules for. Can be of the iptables match format- it already defaults to <code>+</code> which is a wildcard that matches all interface.
 
 backend: hostsfile OR iptables OR iptables_cmd
 -------------

--- a/conf/swabber.yaml
+++ b/conf/swabber.yaml
@@ -7,7 +7,7 @@ bindstrings:
   - tcp://127.0.0.1:22621
 interface: eth+
 backend: iptables_cmd
-logfile: /var/log/swabber.log
+logpath: /var/log/swabber.log
 
 whitelist:
   - 127.0.0.0/8

--- a/conf/swabber.yaml
+++ b/conf/swabber.yaml
@@ -5,7 +5,9 @@ polltime: 60
 bindstrings:
   - tcp://127.0.0.1:22620
   - tcp://127.0.0.1:22621
-interface: eth+
+# "+" matches all interfaces. To only match eth interfaces
+# use interface filter "eth+"
+interface: +
 backend: iptables_cmd
 logpath: /var/log/swabber.log
 

--- a/initscript/swabberd
+++ b/initscript/swabberd
@@ -30,7 +30,7 @@ case "$1" in
 		    ;;
   stop)
   echo -n "Stopping $DESC: "
-  if start-stop-daemon --stop --quiet --oknodo -s HUP --pidfile /var/run/$NAME.pid; then
+  if start-stop-daemon --stop --quiet --pidfile /var/run/$NAME.pid; then
       log_end_msg 0
   else
       log_end_msg 1
@@ -40,7 +40,7 @@ case "$1" in
       status_of_proc -p /var/run/$NAME.pid /usr/bin/$NAME $NAME && exit 0 || exit $?
  ;;
 
-  #reload)
+  reload|force-reload)
   #
   #	If the daemon can reload its config files on the fly
   #	for example by sending it SIGHUP, do it here.
@@ -48,11 +48,11 @@ case "$1" in
   #	If the daemon responds to changes in its config file
   #	directly anyway, make this a do-nothing entry.
   #
-  # echo "Reloading $DESC configuration files."
-  # start-stop-daemon --stop --signal 1 --quiet --pidfile \
-  # /var/run/$NAME.pid --exec $DAEMON
-  #;;
-  restart|force-reload)
+  echo "Reloading $DESC configuration files."
+  start-stop-daemon --stop --signal HUP --quiet --pidfile /var/run/$NAME.pid
+  ;;
+
+  restart)
   #
   #	If the "reload" option is implemented, move the "force-reload"
   #	option to the "reload" entry above. If not, "force-reload" is

--- a/initscript/swabberd.service
+++ b/initscript/swabberd.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Swabber Service
+
+[Service]
+Type=forking
+ExecStart=/usr/local/bin/swabberd
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target
+Alias=swabber.service

--- a/src/swabberd
+++ b/src/swabberd
@@ -127,6 +127,7 @@ class Swabberd(object):
                 if self.cleaner:
                     self.cleaner = BanCleaner(self.config["bantime"], self.config["backend"],
                                               iptables_lock, self.config["interface"])
+                self.banner.start()
                 logging.info("Reloaded config")
 
         signal.signal(signal.SIGTERM, handle_signal)

--- a/src/swabberd
+++ b/src/swabberd
@@ -113,12 +113,16 @@ class Swabberd(object):
                                  self.config["whitelist"], iptables_lock)
 
         def handle_signal(signum, frame):
-            if signum == signal.SIGTERM:
+            if signum in [signal.SIGINT, signal.SIGTERM]:
                 self.banner.stop_running()
                 if self.config["bantime"]:
                     self.running = False
-                logging.warning("Closing on SIGTERM")
-            elif signum == signal.SIGHUP: 
+                if signum == signal.SIGINT:
+                    logging.warning("Closing on SIGINT (KeyboardInterrupt)")
+                else:
+                    logging.warning("Closing on SIGTERM")
+
+            elif signum == signal.SIGHUP:
                 config = get_config(self.configpath)
                 self.banner.stop_running()
                 self.banner = BanFetcher(self.config["bindstrings"],
@@ -130,6 +134,7 @@ class Swabberd(object):
                 self.banner.start()
                 logging.info("Reloaded config")
 
+        signal.signal(signal.SIGINT, handle_signal)
         signal.signal(signal.SIGTERM, handle_signal)
         signal.signal(signal.SIGHUP, handle_signal)
 

--- a/src/swabberd
+++ b/src/swabberd
@@ -57,31 +57,6 @@ def daemon_setup():
     os.setsid()
     os.umask(0)
 
-    # Second fork
-    try:
-        pid = os.fork()
-        if pid > 0:
-            # exit if second parent
-            sys.exit(0)
-    except OSError, e:
-        sys.stderr.write("Second fork failed: %d (%s)\n" % (e.errno, e.strerror))
-        sys.exit(1)
-
-    # redirect standard file descriptors
-    sys.stdout.flush()
-    sys.stderr.flush()
-    si = file("/dev/null", 'r')
-    so = file("/dev/null", 'a+')
-    #se = file("/dev/null", 'a+', 0)
-    os.dup2(si.fileno(), sys.stdin.fileno())
-    os.dup2(so.fileno(), sys.stdout.fileno())
-    #os.dup2(se.fileno(), sys.stderr.fileno())
-
-    # write pidfile
-    #atexit.register(self.delpid)
-    #pid = str(os.getpid())
-    #file(self.pidfile,'w+').write("%s\n" % pid)
-
 def get_config(configpath):
     '''Load the configuration file and update the defaults dictionary
     with any information included in it.


### PR DESCRIPTION
This PR is revision of #16 which retains the Python forking/daemon code. It should be compatible with the sysV init script. 

I have tested the SystemD service on Debian 9. Starting, stopping and reloading the service should all work correctly. I fixed a bug where an exception would be raised when the service was reload twice. The error was caused by the `banfetcher` thread not being restarted after the first reload.

The default interface in the example config file is now `+`. This interface name is passed to the iptables command line. `+` is an iptables interface wildcard which will match all interfaces. 

This PR adds an example service unit file to the repo and includes installation instructions in the README.